### PR TITLE
Refactor payloads and add random generator

### DIFF
--- a/payloads/production_order/create_production_order.json
+++ b/payloads/production_order/create_production_order.json
@@ -1,0 +1,12 @@
+{
+  "number": "{{randomNumber}}",
+  "date_get": "2025-05-26",
+  "required_date": "2025-05-26",
+  "date_complite": "2025-05-26",
+  "priority": "{{randomInt}}",
+  "customer": "{{randomUserName}}",
+  "client_order": 1,
+  "description": "{{randomStreetAddress}}",
+  "avaible_quantity": "{{randomLastName}}",
+  "ready_persent": "{{randomInt}}"
+}

--- a/tests/payload_utils.py
+++ b/tests/payload_utils.py
@@ -1,0 +1,36 @@
+import json
+import random
+import string
+from pathlib import Path
+
+
+def _generate_value(token: str):
+    if token == "{{randomNumber}}":
+        return ''.join(random.choices(string.digits, k=8))
+    if token == "{{randomInt}}":
+        return random.randint(0, 1000)
+    if token == "{{randomUserName}}":
+        return 'user_' + ''.join(random.choices(string.ascii_lowercase, k=8))
+    if token == "{{randomStreetAddress}}":
+        street = random.choice(['Main', 'Oak', 'Elm', 'Pine'])
+        return f"{random.randint(1, 9999)} {street} St"
+    if token == "{{randomLastName}}":
+        return random.choice(['Smith', 'Johnson', 'Williams', 'Brown', 'Jones'])
+    return token
+
+
+def _fill_placeholders(obj):
+    if isinstance(obj, dict):
+        return {k: _fill_placeholders(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_fill_placeholders(v) for v in obj]
+    if isinstance(obj, str) and obj.startswith('{{') and obj.endswith('}}'):
+        return _generate_value(obj)
+    return obj
+
+
+def load_payload(path):
+    path = Path(path)
+    with path.open() as f:
+        data = json.load(f)
+    return _fill_placeholders(data)

--- a/tests/production_order/test_create.py
+++ b/tests/production_order/test_create.py
@@ -1,19 +1,12 @@
+from pathlib import Path
+
 from endpoints.production_order.create import CreateOrder
+from tests.payload_utils import load_payload
 
 def test_create_production_order(auth_headers):
     endpoint = CreateOrder()
-    payload = {
-  "number": "payment_kazakhstan.flx",
-  "date_get": "2025-05-26",
-  "required_date": "2025-05-26",
-  "date_complite": "2025-05-26",
-  "priority": 455,
-  "customer": "Nichole21",
-  "client_order": 1,
-  "description": "6832 Stefanie Station",
-  "avaible_quantity": "Toy",
-  "ready_persent": 101
-}
+    payload_path = Path(__file__).resolve().parents[2] / "payloads" / "production_order" / "create_production_order.json"
+    payload = load_payload(payload_path)
     endpoint.new_object(payload=payload, headers=auth_headers)
     endpoint.check_number(payload['number'])
 


### PR DESCRIPTION
## Summary
- keep payloads outside of tests
- introduce helper to load payloads with random values
- update production order test to read payload from file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684d99f0626483259d612a39d7891843