### PR TITLE
Implement request/response logging

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py')

--- a/endpoints/base_endpoint.py
+++ b/endpoints/base_endpoint.py
@@ -1,7 +1,34 @@
-class Endpoint:
-    response = None
-    response_json = None
-    host = 'http://www.api.dev.pkmt.tech'
+import logging
+from typing import Optional
 
-    def check_response_is_200(self):
-        assert self.response.check_response_is_200() == 200
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+class Endpoint:
+    """Base class for API endpoints."""
+
+    response: Optional[requests.Response] = None
+    response_json = None
+    host = "http://www.api.dev.pkmt.tech"
+
+    def _log_request_response(self) -> None:
+        """Log request and response details for debugging."""
+
+        if not self.response:
+            return
+
+        req = self.response.request
+        logger.debug("Request %s %s", req.method, req.url)
+        logger.debug("Request headers: %s", dict(req.headers))
+        logger.debug("Request body: %s", req.body)
+
+        logger.debug("Response status: %s", self.response.status_code)
+        logger.debug("Response headers: %s", dict(self.response.headers))
+        logger.debug("Response body: %s", self.response.text)
+
+    def check_response_is_200(self) -> None:
+        assert self.response is not None
+        assert self.response.status_code == 200

--- a/endpoints/production_order/create.py
+++ b/endpoints/production_order/create.py
@@ -1,10 +1,18 @@
 import requests
+
 from endpoints.base_endpoint import Endpoint
+
 
 class CreateOrder(Endpoint):
     def new_object(self, payload, headers):
-        self.response =  requests.post(f'{self.host}/ProductionOrder/v1/ProductionOrders/', json=payload, headers=headers)
+        self.response = requests.post(
+            f"{self.host}/ProductionOrder/v1/ProductionOrders/",
+            json=payload,
+            headers=headers,
+        )
         self.response_json = self.response.json()
+        self._log_request_response()
 
     def check_number(self, number):
-        assert self.response_json['number'] == number
+        assert self.response_json["number"] == number
+

--- a/endpoints/production_order/get.py
+++ b/endpoints/production_order/get.py
@@ -3,5 +3,9 @@ from endpoints.base_endpoint import Endpoint
 
 class GetOrder(Endpoint):
     def new_object(self, headers):
-        self.response =  requests.get(f'{self.host}/ProductionOrder/v1/ProductionOrders/', headers=headers)
+        self.response =  requests.get(
+            f'{self.host}/ProductionOrder/v1/ProductionOrders/',
+            headers=headers
+        )
         self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/production_order/get.py
+++ b/endpoints/production_order/get.py
@@ -1,0 +1,7 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetOrder(Endpoint):
+    def new_object(self, headers):
+        self.response =  requests.get(f'{self.host}/ProductionOrder/v1/ProductionOrders/', headers=headers)
+        self.response_json = self.response.json()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 addopts = -ra
-
+log_cli          = true
+log_cli_level    = DEBUG
+log_format       = %(asctime)s [%(levelname)s] %(message)s
+log_date_format  = %H:%M:%S

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,4 @@ def auth_token():
 @pytest.fixture
 def auth_headers(auth_token):
     return {"Authorization": f"JWT {auth_token}"}
+

--- a/tests/production_order/test_create.py
+++ b/tests/production_order/test_create.py
@@ -17,3 +17,4 @@ def test_create_production_order(auth_headers):
     endpoint.new_object(payload=payload, headers=auth_headers)
     endpoint.check_number(payload['number'])
 
+

--- a/tests/production_order/test_create.py
+++ b/tests/production_order/test_create.py
@@ -3,7 +3,7 @@ from endpoints.production_order.create import CreateOrder
 def test_create_production_order(auth_headers):
     endpoint = CreateOrder()
     payload = {
-  "number": "payment_kazakhstan.flx",
+  "number": "payment_test",
   "date_get": "2025-05-26",
   "required_date": "2025-05-26",
   "date_complite": "2025-05-26",

--- a/tests/production_order/test_get.py
+++ b/tests/production_order/test_get.py
@@ -1,0 +1,5 @@
+from endpoints.production_order.get import GetOrder
+
+def test_create_production_order(auth_headers):
+    endpoint = GetOrder()
+    endpoint.new_object(headers=auth_headers)


### PR DESCRIPTION
## Summary
- add logging helper into `Endpoint`
- log request and response when creating an order
- fix newline endings in tests and endpoint files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684eaf83b2c88325b89a5f5860a04cf3