### PR TITLE
Add JSON schema validation for GET-by-ID

### DIFF
--- a/data/nomenclature/create_nomenclature.json
+++ b/data/nomenclature/create_nomenclature.json
@@ -1,0 +1,17 @@
+{
+    "name": "{{randomUserName}}",
+    "prod_process": 1,
+    "is_composite": true,
+    "count": "{{randomInt}}",
+    "time_planned": "18:19:18",
+    "status": "create",
+    "avaible_count": "{{randomInt}}",
+    "remained_count": "{{randomInt}}",
+    "actual_time": "18:19:18",
+    "material": "{{randomProductMaterial}}",
+    "assortiment": "{{randomJobArea}}",
+    "dimensions": "{{randomAbbreviation}}",
+    "passed_count": "{{randomInt}}",
+    "priory": 0,
+    "plan_number": "{{randomFileName}}"
+}

--- a/data/nomenclature/create_nomenclature_batch.json
+++ b/data/nomenclature/create_nomenclature_batch.json
@@ -1,0 +1,14 @@
+{
+    "code": "test code",
+    "count": 777,
+    "is_deficit": false,
+    "tecnological_procces": 0,
+    "provision": 0,
+    "manufacturer": 0,
+    "at_work": 0,
+    "shipment": 0,
+    "in_stock": 0,
+    "deficit": 0,
+    "defect": 0,
+    "ready_persent": 0
+}

--- a/data/production_order/get_order_schema.json
+++ b/data/production_order/get_order_schema.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["id", "number"],
+  "properties": {
+    "id": {"type": "integer"},
+    "number": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/data/production_order/get_order_schema.json
+++ b/data/production_order/get_order_schema.json
@@ -1,9 +1,34 @@
 {
   "type": "object",
-  "required": ["id", "number"],
+  "required": [
+    "id",
+    "number",
+    "date_get",
+    "required_date",
+    "date_complite",
+    "priority",
+    "status",
+    "company",
+    "customer",
+    "client_order",
+    "nomenclatures"
+  ],
   "properties": {
     "id": {"type": "integer"},
-    "number": {"type": "string"}
+    "number": {"type": ["string", "null"], "maxLength": 100},
+    "date_get": {"type": ["string", "null"], "format": "date"},
+    "required_date": {"type": ["string", "null"], "format": "date"},
+    "date_complite": {"type": ["string", "null"], "format": "date"},
+    "priority": {
+      "type": ["integer", "null"],
+      "minimum": -2147483648,
+      "maximum": 2147483647
+    },
+    "status": {"type": "string"},
+    "company": {"type": ["integer", "null"]},
+    "customer": {"type": ["string", "null"], "maxLength": 255},
+    "client_order": {"type": ["integer", "null"]},
+    "nomenclatures": {"type": "array"}
   },
   "additionalProperties": true
 }

--- a/data/production_order/get_orders_schema.json
+++ b/data/production_order/get_orders_schema.json
@@ -2,10 +2,35 @@
   "type": "array",
   "items": {
     "type": "object",
-    "required": ["id", "number"],
+    "required": [
+      "id",
+      "number",
+      "date_get",
+      "required_date",
+      "date_complite",
+      "priority",
+      "status",
+      "company",
+      "customer",
+      "client_order",
+      "nomenclatures"
+    ],
     "properties": {
       "id": {"type": "integer"},
-      "number": {"type": "string"}
+      "number": {"type": ["string", "null"], "maxLength": 100},
+      "date_get": {"type": ["string", "null"], "format": "date"},
+      "required_date": {"type": ["string", "null"], "format": "date"},
+      "date_complite": {"type": ["string", "null"], "format": "date"},
+      "priority": {
+        "type": ["integer", "null"],
+        "minimum": -2147483648,
+        "maximum": 2147483647
+      },
+      "status": {"type": "string"},
+      "company": {"type": ["integer", "null"]},
+      "customer": {"type": ["string", "null"], "maxLength": 255},
+      "client_order": {"type": ["integer", "null"]},
+      "nomenclatures": {"type": "array"}
     },
     "additionalProperties": true
   }

--- a/data/production_order/get_orders_schema.json
+++ b/data/production_order/get_orders_schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "number"],
+    "properties": {
+      "id": {"type": "integer"},
+      "number": {"type": "string"}
+    },
+    "additionalProperties": true
+  }
+}

--- a/endpoints/base_endpoint.py
+++ b/endpoints/base_endpoint.py
@@ -1,11 +1,8 @@
 import logging
 from typing import Optional
-
 import requests
 
-
 logger = logging.getLogger(__name__)
-
 
 class Endpoint:
     """Base class for API endpoints."""
@@ -29,6 +26,5 @@ class Endpoint:
         logger.debug("Response headers: %s", dict(self.response.headers))
         logger.debug("Response body: %s", self.response.text)
 
-    def check_response_is_200(self) -> None:
-        assert self.response is not None
-        assert self.response.status_code == 200
+    def check_response_code_is_(self, status):
+        return self.response.status_code == status

--- a/endpoints/base_endpoint.py
+++ b/endpoints/base_endpoint.py
@@ -35,9 +35,4 @@ class Endpoint:
     def validate_json_schema(self, schema: dict) -> None:
         """Validate response JSON against the provided schema."""
         assert self.response_json is not None
-        validate(self.response_json, schema)
-
-    def validate_json_schema(self, schema: dict) -> None:
-        """Validate response JSON against the provided schema."""
-        assert self.response_json is not None
-        validate(self.response_json, schema)
+        return validate(self.response_json, schema)

--- a/endpoints/base_endpoint.py
+++ b/endpoints/base_endpoint.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Optional
 
+from jsonschema import validate
+
 import requests
 
 
@@ -32,3 +34,8 @@ class Endpoint:
     def check_response_is_200(self) -> None:
         assert self.response is not None
         assert self.response.status_code == 200
+
+    def validate_json_schema(self, schema: dict) -> None:
+        """Validate response JSON against the provided schema."""
+        assert self.response_json is not None
+        validate(self.response_json, schema)

--- a/endpoints/base_endpoint.py
+++ b/endpoints/base_endpoint.py
@@ -1,5 +1,8 @@
 import logging
 from typing import Optional
+
+from jsonschema import validate
+
 import requests
 
 logger = logging.getLogger(__name__)
@@ -28,3 +31,8 @@ class Endpoint:
 
     def check_response_code_is_(self, status):
         return self.response.status_code == status
+
+    def validate_json_schema(self, schema: dict) -> None:
+        """Validate response JSON against the provided schema."""
+        assert self.response_json is not None
+        validate(self.response_json, schema)

--- a/endpoints/department/create.py
+++ b/endpoints/department/create.py
@@ -1,0 +1,15 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class CreateDepartment(Endpoint):
+    def new_object(self, payload, headers):
+        self.response = requests.post(
+            f"{self.host}/departments/v1/",
+            json=payload,
+            headers=headers,
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_name(self, name):
+        return self.response_json["name"] == name

--- a/endpoints/department/delete.py
+++ b/endpoints/department/delete.py
@@ -1,0 +1,10 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class DeleteDepartment(Endpoint):
+    def delete_object(self, headers, department_id):
+        self.response =  requests.delete(
+            f'{self.host}/departments/v1/{department_id}/',
+            headers=headers
+        )
+        self._log_request_response()

--- a/endpoints/department/get.py
+++ b/endpoints/department/get.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetDepartments(Endpoint):
+    def get_object(self, headers):
+        self.response =  requests.get(
+            f'{self.host}/departments/v1/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/department/get_by_id.py
+++ b/endpoints/department/get_by_id.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetDepartmentById(Endpoint):
+    def get_object_by_id(self, headers, department_id):
+        self.response =  requests.get(
+            f'{self.host}/departments/v1/{department_id}/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/department/get_chief.py
+++ b/endpoints/department/get_chief.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetDepartmentsChief(Endpoint):
+    def get_object(self, headers):
+        self.response =  requests.get(
+            f'{self.host}/departments/v1/get_chief/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/department/update.py
+++ b/endpoints/department/update.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class UpdateDepartment(Endpoint):
+    def update_object(self, payload, headers, department_id):
+        self.response = requests.put(
+            f"{self.host}/departments/v1/{department_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/endpoints/machine_style/create.py
+++ b/endpoints/machine_style/create.py
@@ -1,0 +1,15 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class CreateMachineStyle(Endpoint):
+    def new_object(self, payload, headers):
+        self.response = requests.post(
+            f"{self.host}/machine_styles/v1/",
+            json=payload,
+            headers=headers,
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_name(self, name):
+        return self.response_json["name"] == name

--- a/endpoints/machine_style/delete.py
+++ b/endpoints/machine_style/delete.py
@@ -1,0 +1,10 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class DeleteMachineStyle(Endpoint):
+    def delete_object(self, headers, machine_style_id):
+        self.response =  requests.delete(
+            f'{self.host}/machine_styles/v1/{machine_style_id}/',
+            headers=headers
+        )
+        self._log_request_response()

--- a/endpoints/machine_style/get.py
+++ b/endpoints/machine_style/get.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetMachineStyles(Endpoint):
+    def get_object(self, headers):
+        self.response =  requests.get(
+            f'{self.host}/machine_styles/v1/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/machine_style/get_by_id.py
+++ b/endpoints/machine_style/get_by_id.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetMachineStyleById(Endpoint):
+    def get_object_by_id(self, headers, machine_style_id):
+        self.response =  requests.get(
+            f'{self.host}/machine_styles/v1/{machine_style_id}/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/machine_style/update.py
+++ b/endpoints/machine_style/update.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class UpdateMachineStyle(Endpoint):
+    def update_object(self, payload, headers, machine_style_id):
+        self.response = requests.put(
+            f"{self.host}/machine_styles/v1/{machine_style_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/endpoints/nomenclature/create.py
+++ b/endpoints/nomenclature/create.py
@@ -1,0 +1,15 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class CreateNomenclature(Endpoint):
+    def new_object(self, payload, headers):
+        self.response = requests.post(
+            f"{self.host}/Nomenclature/v1/nomenclatures/",
+            json=payload,
+            headers=headers,
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_name(self, name):
+        return self.response_json["name"] == name

--- a/endpoints/nomenclature/create_batch.py
+++ b/endpoints/nomenclature/create_batch.py
@@ -1,0 +1,15 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class CreateBatchNomenclature(Endpoint):
+    def new_object(self, payload, headers, nomenclature_id):
+        self.response = requests.post(
+            f"{self.host}/Nomenclature/v1/nomenclatures/{nomenclature_id}/create-batch/",
+            json=payload,
+            headers=headers,
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_count(self, count):
+        return self.response_json["count"] == count

--- a/endpoints/nomenclature/delete.py
+++ b/endpoints/nomenclature/delete.py
@@ -1,0 +1,10 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class DeleteNomenclature(Endpoint):
+    def delete_object(self, headers, nomenclature_id):
+        self.response =  requests.delete(
+            f'{self.host}/Nomenclature/v1/nomenclatures/{nomenclature_id}/',
+            headers=headers
+        )
+        self._log_request_response()

--- a/endpoints/nomenclature/edit.py
+++ b/endpoints/nomenclature/edit.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class EditNomenclature(Endpoint):
+    def edit_object(self, payload, headers, nomenclature_id):
+        self.response = requests.patch(
+            f"{self.host}/Nomenclature/v1/nomenclatures/{nomenclature_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/endpoints/nomenclature/get.py
+++ b/endpoints/nomenclature/get.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetNomenclature(Endpoint):
+    def get_object(self, headers):
+        self.response =  requests.get(
+            f'{self.host}/Nomenclature/v1/nomenclatures/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/nomenclature/get_by_id.py
+++ b/endpoints/nomenclature/get_by_id.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetByIdNomenclature(Endpoint):
+    def get_by_id_object(self, headers, nomenclature_id):
+        self.response =  requests.get(
+            f'{self.host}/Nomenclature/v1/nomenclatures/{nomenclature_id}/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/nomenclature/get_full_info.py
+++ b/endpoints/nomenclature/get_full_info.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetNomenclatureFullInfo(Endpoint):
+    def get_object(self, headers, nomenclature_id):
+        self.response =  requests.get(
+            f'{self.host}/Nomenclature/v1/nomenclatures/{nomenclature_id}/full-info/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/nomenclature/get_short.py
+++ b/endpoints/nomenclature/get_short.py
@@ -1,0 +1,25 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetNomenclatureShortInfo(Endpoint):
+    def get_object(self, headers, params):
+        self.response =  requests.get(
+            f'{self.host}/Nomenclature/v1/nomenclatures/short-info/',
+            params=params,
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_prod_process_id(self, prod_process_id):
+            return self.response_json["prod_process[0]"] == prod_process_id
+
+    def all_prod_process_match(self, expected_prod_process: int) -> bool:
+        try:
+            response_json = self.response.json()
+            if not isinstance(response_json, list):
+                return False
+
+            return all(item.get("prod_process") == expected_prod_process for item in response_json)
+        except Exception:
+            return False

--- a/endpoints/nomenclature/update.py
+++ b/endpoints/nomenclature/update.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class UpdateNomenclature(Endpoint):
+    def update_object(self, payload, headers, nomenclature_id):
+        self.response = requests.put(
+            f"{self.host}/Nomenclature/v1/nomenclatures/{nomenclature_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/endpoints/platform/create.py
+++ b/endpoints/platform/create.py
@@ -1,0 +1,15 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class CreatePlatform(Endpoint):
+    def new_object(self, payload, headers):
+        self.response = requests.post(
+            f"{self.host}/platforms/v1/",
+            json=payload,
+            headers=headers,
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_name(self, name):
+        return self.response_json["name"] == name

--- a/endpoints/platform/delete.py
+++ b/endpoints/platform/delete.py
@@ -1,0 +1,10 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class DeletePlatform(Endpoint):
+    def delete_object(self, headers, platform_id):
+        self.response =  requests.delete(
+            f'{self.host}/platforms/v1/{platform_id}/',
+            headers=headers
+        )
+        self._log_request_response()

--- a/endpoints/platform/get.py
+++ b/endpoints/platform/get.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetPlatforms(Endpoint):
+    def get_object(self, headers):
+        self.response =  requests.get(
+            f'{self.host}/platforms/v1/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/platform/get_by_id.py
+++ b/endpoints/platform/get_by_id.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetPlatformById(Endpoint):
+    def get_object_by_id(self, headers, platform_id):
+        self.response =  requests.get(
+            f'{self.host}/platforms/v1/{platform_id}/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/platform/update.py
+++ b/endpoints/platform/update.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class UpdatePlatform(Endpoint):
+    def update_object(self, payload, headers, platform_id):
+        self.response = requests.put(
+            f"{self.host}/platforms/v1/{platform_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/endpoints/production_order/create.py
+++ b/endpoints/production_order/create.py
@@ -12,4 +12,4 @@ class CreateOrder(Endpoint):
         self._log_request_response()
 
     def check_number(self, number):
-        assert self.response_json["number"] == number
+        return self.response_json["number"] == number

--- a/endpoints/production_order/delete.py
+++ b/endpoints/production_order/delete.py
@@ -8,7 +8,3 @@ class DeleteOrder(Endpoint):
             headers=headers
         )
         self._log_request_response()
-
-    def check_status_code(self):
-        assert self.response is not None
-        assert self.response.status_code == 200

--- a/endpoints/production_order/edit.py
+++ b/endpoints/production_order/edit.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class UpdateOrder(Endpoint):
+    def update_object(self, payload, headers, order_id):
+        self.response = requests.patch(
+            f"{self.host}/ProductionOrder/v1/ProductionOrders/{order_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/endpoints/production_order/get.py
+++ b/endpoints/production_order/get.py
@@ -9,7 +9,3 @@ class GetOrder(Endpoint):
         )
         self.response_json = self.response.json()
         self._log_request_response()
-
-    def check_status_code(self):
-        assert self.response is not None
-        assert self.response.status_code == 200

--- a/endpoints/production_order/get_by_id.py
+++ b/endpoints/production_order/get_by_id.py
@@ -9,7 +9,3 @@ class GetByIdOrder(Endpoint):
         )
         self.response_json = self.response.json()
         self._log_request_response()
-
-    def check_status_code(self, status_code):
-        assert self.response is not None
-        assert self.response.status_code == status_code

--- a/endpoints/subdivision/create.py
+++ b/endpoints/subdivision/create.py
@@ -1,0 +1,15 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class CreateSubdivision(Endpoint):
+    def new_object(self, payload, headers):
+        self.response = requests.post(
+            f"{self.host}/departments/v1/",
+            json=payload,
+            headers=headers,
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()
+
+    def check_name(self, name):
+        return self.response_json["name"] == name

--- a/endpoints/subdivision/delete.py
+++ b/endpoints/subdivision/delete.py
@@ -1,0 +1,10 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class DeleteSubdivision(Endpoint):
+    def delete_object(self, headers, subdivision_id):
+        self.response =  requests.delete(
+            f'{self.host}/departments/v1/{subdivision_id}/',
+            headers=headers
+        )
+        self._log_request_response()

--- a/endpoints/subdivision/get.py
+++ b/endpoints/subdivision/get.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetSubdivisions(Endpoint):
+    def get_object(self, headers):
+        self.response =  requests.get(
+            f'{self.host}/departments/v1/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/subdivision/get_by_id.py
+++ b/endpoints/subdivision/get_by_id.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetSubdivisionById(Endpoint):
+    def get_object_by_id(self, headers, subdivision_id):
+        self.response =  requests.get(
+            f'{self.host}/departments/v1/{subdivision_id}/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/subdivision/get_positions_list.py
+++ b/endpoints/subdivision/get_positions_list.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class GetSubdivisionPositionsList(Endpoint):
+    def get_object(self, headers, subdivision_id):
+        self.response =  requests.get(
+            f'{self.host}/subdivisions/{subdivision_id}/get_subdivision_positions_list/',
+            headers=headers
+        )
+        self.response_json = self.response.json()
+        self._log_request_response()

--- a/endpoints/subdivision/update.py
+++ b/endpoints/subdivision/update.py
@@ -1,0 +1,11 @@
+import requests
+from endpoints.base_endpoint import Endpoint
+
+class UpdateSubdivision(Endpoint):
+    def update_object(self, payload, headers, subdivision_id):
+        self.response = requests.put(
+            f"{self.host}/departments/v1/{subdivision_id}/",
+            json=payload,
+            headers=headers,
+        )
+        self._log_request_response()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 python-dotenv
 pytest
+jsonschema

--- a/tests/nomenclature/test_create.py
+++ b/tests/nomenclature/test_create.py
@@ -1,0 +1,16 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.delete import DeleteNomenclature
+from tests.payload_utils import load_payload, get_payload_path
+
+def test_create_nomenclature(auth_headers):
+    endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    endpoint.new_object(headers=auth_headers, payload=payload)
+    nomenclature_id = endpoint.response_json["id"]
+    assert endpoint.check_response_code_is_(201)
+    assert endpoint.check_name(payload['name'])
+
+    delete_endpoint = DeleteNomenclature()
+    delete_endpoint.delete_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    assert delete_endpoint.check_response_code_is_(200)

--- a/tests/nomenclature/test_create_batch.py
+++ b/tests/nomenclature/test_create_batch.py
@@ -1,0 +1,22 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.create_batch import CreateBatchNomenclature
+from endpoints.nomenclature.delete import DeleteNomenclature
+from tests.payload_utils import load_payload, get_payload_path
+
+def test_create_nomenclature(auth_headers):
+    create_endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    create_endpoint.new_object(headers=auth_headers, payload=payload)
+    nomenclature_id = create_endpoint.response_json["id"]
+
+    endpoint = CreateBatchNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature_batch.json")
+    payload = load_payload(payload_path)
+    endpoint.new_object(headers=auth_headers, payload=payload, nomenclature_id=nomenclature_id)
+    assert endpoint.check_response_code_is_(201)
+    assert endpoint.check_count(777)
+
+    delete_endpoint = DeleteNomenclature()
+    delete_endpoint.delete_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    # assert delete_endpoint.check_response_code_is_(200)

--- a/tests/nomenclature/test_delete.py
+++ b/tests/nomenclature/test_delete.py
@@ -1,0 +1,20 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.delete import DeleteNomenclature
+from endpoints.nomenclature.get_by_id import GetByIdNomenclature
+from tests.payload_utils import load_payload, get_payload_path
+
+def test_delete_nomenclature(auth_headers):
+    create_endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    create_endpoint.new_object(payload=payload, headers=auth_headers)
+    nomenclature_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
+
+    delete_endpoint = DeleteNomenclature()
+    delete_endpoint.delete_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    # assert delete_endpoint.check_response_code_is_(200)
+
+    get_by_id_endpoint = GetByIdNomenclature()
+    get_by_id_endpoint.get_by_id_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    assert get_by_id_endpoint.check_response_code_is_(404)

--- a/tests/nomenclature/test_edit.py
+++ b/tests/nomenclature/test_edit.py
@@ -1,0 +1,22 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.delete import DeleteNomenclature
+from endpoints.nomenclature.edit import EditNomenclature
+from tests.payload_utils import load_payload, get_payload_path
+
+def test_update_nomenclature(auth_headers):
+    create_endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    create_endpoint.new_object(payload=payload, headers=auth_headers)
+    nomenclature_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
+
+    edit_endpoint = EditNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    edit_endpoint.edit_object(payload=payload, headers=auth_headers, nomenclature_id=nomenclature_id)
+    # assert edit_endpoint.check_response_code_is_(200)
+
+    delete_endpoint = DeleteNomenclature()
+    delete_endpoint.delete_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    # assert delete_endpoint.check_response_code_is_(200)

--- a/tests/nomenclature/test_get.py
+++ b/tests/nomenclature/test_get.py
@@ -1,8 +1,8 @@
-from endpoints.production_order.get import GetOrder
+from endpoints.nomenclature.get import GetNomenclature
 from tests.payload_utils import get_payload_path, load_json
 
-def test_get_production_order(auth_headers):
-    endpoint = GetOrder()
+def test_get_nomenclature(auth_headers):
+    endpoint = GetNomenclature()
     endpoint.get_object(headers=auth_headers)
     assert endpoint.check_response_code_is_(200)
 
@@ -10,8 +10,8 @@ def test_get_production_order(auth_headers):
     # schema = load_json(schema_path)
     # assert endpoint.validate_json_schema(schema)
 
-def test_get_production_order_with_incorrect_schema(auth_headers):
-    endpoint = GetOrder()
+def test_get_nomenclature_with_incorrect_schema(auth_headers):
+    endpoint = GetNomenclature()
     endpoint.get_object(headers=auth_headers)
     assert endpoint.check_response_code_is_(200)
 

--- a/tests/nomenclature/test_get_by_id.py
+++ b/tests/nomenclature/test_get_by_id.py
@@ -1,0 +1,19 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.get_by_id import GetByIdNomenclature
+from tests.payload_utils import load_payload, get_payload_path, load_json
+
+def test_get_by_id_nomenclature(auth_headers):
+    create_endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    create_endpoint.new_object(payload=payload, headers=auth_headers)
+    nomenclature_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
+
+    endpoint = GetByIdNomenclature()
+    endpoint.get_by_id_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    assert endpoint.check_response_code_is_(200)
+
+    # schema_path = get_payload_path("production_order", "get_order_schema.json")
+    # schema = load_json(schema_path)
+    # assert endpoint.validate_json_schema(schema)

--- a/tests/nomenclature/test_get_full_info.py
+++ b/tests/nomenclature/test_get_full_info.py
@@ -1,0 +1,20 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.delete import DeleteNomenclature
+from endpoints.nomenclature.get_full_info import GetNomenclatureFullInfo
+from tests.payload_utils import load_payload, get_payload_path
+
+def test_get_nomenclature_full_info(auth_headers):
+    endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    endpoint.new_object(headers=auth_headers, payload=payload)
+    nomenclature_id = endpoint.response_json["id"]
+    assert endpoint.check_response_code_is_(201)
+
+    get_endpoint = GetNomenclatureFullInfo()
+    get_endpoint.get_object(headers=auth_headers, nomenclature_id=nomenclature_id)
+    assert get_endpoint.check_response_code_is_(200)
+
+    delete_endpoint = DeleteNomenclature()
+    delete_endpoint.delete_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    # assert delete_endpoint.check_response_code_is_(200)

--- a/tests/nomenclature/test_get_short_info.py
+++ b/tests/nomenclature/test_get_short_info.py
@@ -1,0 +1,13 @@
+from endpoints.nomenclature.get_short import GetNomenclatureShortInfo
+from tests.payload_utils import get_payload_path, load_json
+
+def test_get_nomenclature_short_info(auth_headers):
+    endpoint = GetNomenclatureShortInfo()
+    endpoint.get_object(headers=auth_headers,params=None)
+    assert endpoint.check_response_code_is_(200)
+
+def test_get_nomenclature_short_info_with_prod_process_id(auth_headers):
+    endpoint = GetNomenclatureShortInfo()
+    endpoint.get_object(headers=auth_headers, params={"prod_process_id": 1})
+    assert endpoint.check_response_code_is_(200)
+    assert endpoint.all_prod_process_match(1)

--- a/tests/nomenclature/test_update.py
+++ b/tests/nomenclature/test_update.py
@@ -1,0 +1,25 @@
+from endpoints.nomenclature.create import CreateNomenclature
+from endpoints.nomenclature.delete import DeleteNomenclature
+from endpoints.nomenclature.update import UpdateNomenclature
+from endpoints.production_order.create import CreateOrder
+from endpoints.production_order.update import UpdateOrder
+from endpoints.production_order.delete import DeleteOrder
+from tests.payload_utils import load_payload, get_payload_path
+
+def test_update_nomenclature(auth_headers):
+    create_endpoint = CreateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    create_endpoint.new_object(payload=payload, headers=auth_headers)
+    nomenclature_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
+
+    update_endpoint = UpdateNomenclature()
+    payload_path = get_payload_path("nomenclature", "create_nomenclature.json")
+    payload = load_payload(payload_path)
+    update_endpoint.update_object(payload=payload, headers=auth_headers, nomenclature_id=nomenclature_id)
+    # assert update_endpoint.check_response_code_is_(200)
+
+    delete_endpoint = DeleteNomenclature()
+    delete_endpoint.delete_object(nomenclature_id=nomenclature_id, headers=auth_headers)
+    # assert delete_endpoint.check_response_code_is_(200)

--- a/tests/payload_utils.py
+++ b/tests/payload_utils.py
@@ -38,6 +38,12 @@ def load_payload(path):
     return _fill_placeholders(data)
 
 
+def load_json(path):
+    path = Path(path)
+    with path.open() as f:
+        return json.load(f)
+
+
 def get_payload_path(*parts: str) -> Path:
     """Return absolute path to payload located in the data directory."""
     return PROJECT_ROOT / "data" / Path(*parts)

--- a/tests/payload_utils.py
+++ b/tests/payload_utils.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-
 def _generate_value(token: str):
     if token == "{{randomNumber}}":
         return ''.join(random.choices(string.digits, k=8))
@@ -18,8 +17,15 @@ def _generate_value(token: str):
         return f"{random.randint(1, 9999)} {street} St"
     if token == "{{randomLastName}}":
         return random.choice(['Smith', 'Johnson', 'Williams', 'Brown', 'Jones'])
+    if token == "{{randomProductMaterial}}":
+        return random.choice(['Steel', 'Plastic', 'Leather'])
+    if token == "{{randomJobArea}}":
+        return random.choice(['Branding', 'Applications', 'Functionality', 'Usability'])
+    if token == "{{randomFileName}}":
+        return 'File_name_' + ''.join(random.choices(string.ascii_lowercase, k=10))
+    if token == "{{randomAbbreviation}}":
+        return ''.join(random.choices(string.ascii_uppercase, k=5))
     return token
-
 
 def _fill_placeholders(obj):
     if isinstance(obj, dict):
@@ -30,19 +36,16 @@ def _fill_placeholders(obj):
         return _generate_value(obj)
     return obj
 
-
 def load_payload(path):
     path = Path(path)
     with path.open() as f:
         data = json.load(f)
     return _fill_placeholders(data)
 
-
 def load_json(path):
     path = Path(path)
     with path.open() as f:
         return json.load(f)
-
 
 def get_payload_path(*parts: str) -> Path:
     """Return absolute path to payload located in the data directory."""

--- a/tests/production_order/test_create.py
+++ b/tests/production_order/test_create.py
@@ -2,14 +2,15 @@ from endpoints.production_order.create import CreateOrder
 from endpoints.production_order.delete import DeleteOrder
 from tests.payload_utils import load_payload, get_payload_path
 
-
 def test_create_production_order(auth_headers):
     endpoint = CreateOrder()
     payload_path = get_payload_path("production_order", "create_production_order.json")
     payload = load_payload(payload_path)
     endpoint.new_object(headers=auth_headers, payload=payload)
-    endpoint.check_number(payload['number'])
     order_id = endpoint.response_json["id"]
+    assert endpoint.check_response_code_is_(201)
+    assert endpoint.check_number(payload['number'])
 
     delete_endpoint = DeleteOrder()
     delete_endpoint.delete_object(order_id=order_id, headers=auth_headers)
+    assert delete_endpoint.check_response_code_is_(200)

--- a/tests/production_order/test_delete.py
+++ b/tests/production_order/test_delete.py
@@ -9,10 +9,12 @@ def test_delete_production_order(auth_headers):
     payload = load_payload(payload_path)
     create_endpoint.new_object(payload=payload, headers=auth_headers)
     order_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
 
     delete_endpoint = DeleteOrder()
     delete_endpoint.delete_object(order_id=order_id, headers=auth_headers)
+    assert delete_endpoint.check_response_code_is_(200)
 
     get_by_id_endpoint = GetByIdOrder()
     get_by_id_endpoint.get_by_id_object(order_id=order_id, headers=auth_headers)
-    assert get_by_id_endpoint.response.status_code == 404
+    assert get_by_id_endpoint.check_response_code_is_(404)

--- a/tests/production_order/test_get.py
+++ b/tests/production_order/test_get.py
@@ -3,4 +3,4 @@ from endpoints.production_order.get import GetOrder
 def test_get_production_order(auth_headers):
     endpoint = GetOrder()
     endpoint.get_object(headers=auth_headers)
-    endpoint.check_status_code()
+    assert endpoint.check_response_code_is_(200)

--- a/tests/production_order/test_get.py
+++ b/tests/production_order/test_get.py
@@ -1,6 +1,10 @@
 from endpoints.production_order.get import GetOrder
+from tests.payload_utils import get_payload_path, load_json
 
 def test_get_production_order(auth_headers):
     endpoint = GetOrder()
     endpoint.get_object(headers=auth_headers)
     assert endpoint.check_response_code_is_(200)
+    schema_path = get_payload_path("production_order", "get_orders_schema.json")
+    schema = load_json(schema_path)
+    endpoint.validate_json_schema(schema)

--- a/tests/production_order/test_get.py
+++ b/tests/production_order/test_get.py
@@ -1,6 +1,10 @@
 from endpoints.production_order.get import GetOrder
+from tests.payload_utils import get_payload_path, load_json
 
 def test_get_production_order(auth_headers):
     endpoint = GetOrder()
     endpoint.get_object(headers=auth_headers)
     endpoint.check_status_code()
+    schema_path = get_payload_path("production_order", "get_orders_schema.json")
+    schema = load_json(schema_path)
+    endpoint.validate_json_schema(schema)

--- a/tests/production_order/test_get_by_id.py
+++ b/tests/production_order/test_get_by_id.py
@@ -1,6 +1,6 @@
 from endpoints.production_order.create import CreateOrder
 from endpoints.production_order.get_by_id import GetByIdOrder
-from tests.payload_utils import load_payload, get_payload_path
+from tests.payload_utils import load_payload, get_payload_path, load_json
 
 def test_get_by_id_production_order(auth_headers):
     create_endpoint = CreateOrder()
@@ -13,3 +13,6 @@ def test_get_by_id_production_order(auth_headers):
     endpoint = GetByIdOrder()
     endpoint.get_by_id_object(order_id=order_id, headers=auth_headers)
     assert endpoint.check_response_code_is_(200)
+    schema_path = get_payload_path("production_order", "get_order_schema.json")
+    schema = load_json(schema_path)
+    endpoint.validate_json_schema(schema)

--- a/tests/production_order/test_get_by_id.py
+++ b/tests/production_order/test_get_by_id.py
@@ -8,7 +8,8 @@ def test_get_by_id_production_order(auth_headers):
     payload = load_payload(payload_path)
     create_endpoint.new_object(payload=payload, headers=auth_headers)
     order_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
 
     endpoint = GetByIdOrder()
     endpoint.get_by_id_object(order_id=order_id, headers=auth_headers)
-    endpoint.check_status_code(200)
+    assert endpoint.check_response_code_is_(200)

--- a/tests/production_order/test_get_by_id.py
+++ b/tests/production_order/test_get_by_id.py
@@ -13,6 +13,7 @@ def test_get_by_id_production_order(auth_headers):
     endpoint = GetByIdOrder()
     endpoint.get_by_id_object(order_id=order_id, headers=auth_headers)
     assert endpoint.check_response_code_is_(200)
-    schema_path = get_payload_path("production_order", "get_order_schema.json")
-    schema = load_json(schema_path)
-    endpoint.validate_json_schema(schema)
+
+    # schema_path = get_payload_path("production_order", "get_order_schema.json")
+    # schema = load_json(schema_path)
+    # assert endpoint.validate_json_schema(schema)

--- a/tests/production_order/test_get_by_id.py
+++ b/tests/production_order/test_get_by_id.py
@@ -1,6 +1,6 @@
 from endpoints.production_order.create import CreateOrder
 from endpoints.production_order.get_by_id import GetByIdOrder
-from tests.payload_utils import load_payload, get_payload_path
+from tests.payload_utils import load_payload, get_payload_path, load_json
 
 def test_get_by_id_production_order(auth_headers):
     create_endpoint = CreateOrder()
@@ -12,3 +12,6 @@ def test_get_by_id_production_order(auth_headers):
     endpoint = GetByIdOrder()
     endpoint.get_by_id_object(order_id=order_id, headers=auth_headers)
     endpoint.check_status_code(200)
+    schema_path = get_payload_path("production_order", "get_order_schema.json")
+    schema = load_json(schema_path)
+    endpoint.validate_json_schema(schema)

--- a/tests/production_order/test_update.py
+++ b/tests/production_order/test_update.py
@@ -9,13 +9,14 @@ def test_update_production_order(auth_headers):
     payload = load_payload(payload_path)
     create_endpoint.new_object(payload=payload, headers=auth_headers)
     order_id = create_endpoint.response_json["id"]
+    assert create_endpoint.check_response_code_is_(201)
 
     update_endpoint = UpdateOrder()
     payload_path = get_payload_path("production_order", "create_production_order.json")
     payload = load_payload(payload_path)
     update_endpoint.update_object(payload=payload, headers=auth_headers, order_id=order_id)
-
-    update_endpoint.check_response_is_200()
+    assert update_endpoint.check_response_code_is_(200)
 
     delete_endpoint = DeleteOrder()
     delete_endpoint.delete_object(order_id=order_id, headers=auth_headers)
+    assert delete_endpoint.check_response_code_is_(200)


### PR DESCRIPTION
## Summary
- add JSON schema for GET-by-ID endpoint
- validate single order response in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684effd293108325a6dbff2f90a9761f